### PR TITLE
Minor improvements

### DIFF
--- a/libs/videocore_mailbox/src/framebuffer.rs
+++ b/libs/videocore_mailbox/src/framebuffer.rs
@@ -107,8 +107,10 @@ impl FrameBuffer {
 
     fn color_to_slice(&self, color: Color) -> ([u8; 4], usize) {
         match (self.depth, self.pixel_order) {
-            (24, PixelOrder::RGB) => ([color.r, color.g, color.b, 0], 4),
-            (24, PixelOrder::BGR) => ([color.b, color.g, color.r, 0], 4),
+            (24, PixelOrder::RGB) => ([color.r, color.g, color.b, 0], 3),
+            (24, PixelOrder::BGR) => ([color.b, color.g, color.r, 0], 3),
+            (32, PixelOrder::RGB) => ([color.r, color.g, color.b, 255], 4),
+            (32, PixelOrder::BGR) => ([color.b, color.g, color.r, 255], 4),
             _ => {
                 #[cold]
                 fn do_panic(depth: u32, pixel_order: PixelOrder) -> ! {

--- a/libs/videocore_mailbox/src/lib.rs
+++ b/libs/videocore_mailbox/src/lib.rs
@@ -45,7 +45,6 @@ impl<'a> VideoCore<'a> {
     pub fn allocate_framebuffer(&mut self, width: u32, height: u32, depth: u32) -> FrameBuffer {
         let response = mailbox::Request::new()
             .set(items::FramebufferScreenSize { width, height })
-            .set(items::FramebufferVirtualScreenSize { width, height })
             .set(items::FramebufferDepth { depth })
             .set(items::FramebufferPixelOrder {
                 order: PixelOrder::RGB,
@@ -54,7 +53,6 @@ impl<'a> VideoCore<'a> {
             .send(self.peripherals, Channel::PropertyToVC);
 
         let (screen_size, response) = response.pop();
-        let (_virtual_screen_size, response) = response.pop();
         let (depth, response) = response.pop();
         let (pixel_order, response) = response.pop();
         let allocation = response.pop();

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,10 +64,12 @@ pub extern "C" fn kernel_main() -> ! {
     if hardware.is_primary_core() {
         let mut videocore = unsafe { VideoCore::new(hardware.mmio_base_address) };
 
-        let framebuffer = videocore.allocate_framebuffer(800, 600, 24);
+        let framebuffer = videocore.allocate_framebuffer(1366, 768, 24);
+        let (width, height) = (framebuffer.width(), framebuffer.height());
         crate::output::framebuffer::init(framebuffer);
 
         info!("Hello Rust Kernel world!");
+        info!("Framebuffer is {}x{} pixels", width, height);
 
         let mut memory: Option<AtagMemory> = None;
         if let Some(ptr) = NonNull::new(*ATAG_ADDR as *mut ()) {


### PR DESCRIPTION
Added an `AtomicMutex::try_lock`
Added support for 32-bit framebuffer depth
Removed an unneeded framebuffer virtual screen size call
Framebuffer will now print its size
Made output::print not deadlock if the framebuffer is already locked